### PR TITLE
Feature/issue16

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Installation
 
    If you see this message install the Python Qt4 developer tools by running::
 
-       $ sudo apt-get install pyqt4-dev-tool.
+       $ sudo apt-get install pyqt4-dev-tools
 
    Another commmon error::
 

--- a/circle_craters.py
+++ b/circle_craters.py
@@ -342,7 +342,7 @@ class CircleCraters(object):
         header = [
             '# Diam file for Craterstats',
             '# Date of measurement export = {}'.format(current_datetime),
-            '#', 
+            '#',
             'Total_area = {} <km^2>'.format(total_area),
             '#',
             '#diameter, fraction, lon, lat',
@@ -525,10 +525,9 @@ class CircleCraters(object):
             self.transform_point(xform, line[0]),
             self.transform_point(xform, line[1]),
         ]
-        new_line_geometry = QgsGeometry.fromPolyline(transformed)
 
         distance_area = self.get_distance_area(self.layer)
-        actual_line_distance = distance_area.measureArea(new_line_geometry)
+        actual_line_distance = distance_area.measureLine(transformed[0],transformed[1])
 
         # Translate circle center to units of degrees
         center_in_degrees = xform.transform(circle.center.x, circle.center.y)


### PR DESCRIPTION
Crater diameter values are zero when computed using QgsDistanceArea.measureArea() method in QGIS 2.14. If measureArea() method is replaced by measureLine(), diameter values obtained match expected values (see screenshot attached)

![screen shot 2017-02-28 at 10 12 20](https://cloud.githubusercontent.com/assets/9471654/23398890/86ffc1ce-fd9e-11e6-8a91-e7b272b49880.png)
