### PR TITLE
Circle-craters porting to Python3 QGIS-3.16

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Contributors
 ------------
 
 * Trevor Olson <trevor@heytrevor.com>
+* Alessandro Frigeri <alessandro.frigeri@inaf.it>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+CircleCraters changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+
+
+## [0.2] - 2019-06-14
+### Changed
+- Ported to QGIS 3.x by [@afrigeri](https://github.com/afrigeri), after adaptations done for a journal paper: https://doi.org/10.1016/j.icarus.2018.08.015 (see supplementary materials)

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,18 @@ LOCALES =
 #LRELEASE = lrelease
 #LRELEASE = lrelease-qt4
 
+# OSX: darwin
+# Linux: linux
+OS_NAME := $(shell uname -s | tr A-Z a-z)
+
+ifeq ($(OS_NAME), linux)
+QGIS_PY_DIR=".local/share/QGIS/QGIS3/profiles/default/"
+endif
+ifeq ($(OS_NAME), darwin)
+QGIS_PY_DIR="Library/Application Support/QGIS/QGIS3/profiles/default/"
+endif
+
+# QGIS_PY_DIR=$$HOME/pippo
 
 # translation
 SOURCES = \
@@ -75,14 +87,15 @@ PLUGIN_UPLOAD = $(c)/plugin_upload.py
 
 RESOURCE_SRC=$(shell grep '^ *<file' resources.qrc | sed 's@</file>@@g;s/.*>//g' | tr '\n' ' ')
 
-QGISDIR=.qgis2
+#QGISDIR=.qgis2
+QGISDIR=$(QGIS_PY_DIR)
 
 default: compile
 
 compile: $(COMPILED_RESOURCE_FILES)
 
 %_rc.py : %.qrc $(RESOURCES_SRC)
-	pyrcc4 -o $*_rc.py  $<
+	pyrcc5 -o $*_rc.py  $<
 
 %.qm : %.ts
 	$(LRELEASE) $<

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ A crater-counting python plugin for `QGIS`_.
 
 Current Status: In Testing
 
-Written for and tested on QGIS version 2.6 (Brighton).
+Originally written for and tested on QGIS version 2.6 (Brighton). Currently ported to QGIS version 3.6.
 
 Features include:
 

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Details
 
 * This plugin will be submitted to the QGIS plugin repository.
 
-* At this time the plugin does not work properly on QGIS 2.8 (Wien)
+* At this time the plugin does works properly on QGIS 3.4/3.6
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -57,11 +57,11 @@ Installation
 
 5. You may get see the following error messages::
 
-       make: pyrcc4: Command not found.
+       make: pyrcc5: Command not found.
 
    If you see this message install the Python Qt4 developer tools by running::
 
-       $ sudo apt-get install pyqt4-dev-tool.
+       $ sudo apt-get install pyqt5-dev-tool.
 
    Another commmon error::
 

--- a/README.rst
+++ b/README.rst
@@ -43,8 +43,13 @@ Installation
    downloading a zipfile.
 
 3. Use the makefile to compile and copy the files to the QGIS plugin directory
-   (run make deploy). The QGIS plugin directory should be in
-   ~/.qgis2/python/plugins.
+   (run make deploy). 
+
+   On GNU/Linux systems, the QGIS plugin directory should be in 
+   ~/.local/share/QGIS/QGIS3/profiles/default/python/plugins/
+
+   On OSX system, the QGIS plugin directory should be in
+   ~/Library/Application\ Support/QGIS/QGIS3/profiles/default/python/plugins/
 
 4. On the command line run::
 

--- a/README.rst
+++ b/README.rst
@@ -83,26 +83,7 @@ Installation Tips for QGIS
 `Instructions on QGIS.org`_. Hopefully this encourages you to try out QGIS if
 you have not used it before for planetary data!
 
-Alternate Install For Mac OSX:
-
-The QGIS website links to a set of Mac OS X installers for QGIS. An alternative
-is to use Homebrew.
-
-1. Install `Homebrew`_
-
-2. Install GDAL with home brew
-
-3. Install Qt with home brew (remember to link, QGIS 2.6 uses Qt version 4.8 at
-   this time)
-
-4. Install Pyqt with home brew
-
-5. Install Numpy with home brew
-
-6. Install Matplotlib with home brew
-
-7. Install QGIS. Note: The brew/science tap is not the most stable tap for QGIS.
-   It is recommended to use `this tap`_.
+Windows / Linux / MacOSX QGIS Installers: https://qgis.org/en/site/forusers/download.html
 
 Contributing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ A crater-counting python plugin for `QGIS`_.
 
 Current Status: In Testing
 
-Originally written for and tested on QGIS version 2.6 (Brighton). Ported to python3/QGIS version 3.6.
+Originally written for and tested on QGIS version 2.6 (Brighton). Ported to python3/QGIS version 3.16.
 
 Features include:
 

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ A crater-counting python plugin for `QGIS`_.
 
 Current Status: In Testing
 
-Originally written for and tested on QGIS version 2.6 (Brighton). Currently ported to QGIS version 3.6.
+Originally written for and tested on QGIS version 2.6 (Brighton). Ported to python3/QGIS version 3.6.
 
 Features include:
 

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Details
 
 * This plugin will be submitted to the QGIS plugin repository.
 
-* At this time the plugin does works properly on QGIS 3.4/3.6
+* At this time the plugin does works on QGIS 3.16
 
 Installation
 ------------

--- a/choose_layers_dialog.py
+++ b/choose_layers_dialog.py
@@ -14,7 +14,7 @@
 
 import os
 
-from PyQt4 import QtGui, QtCore, uic
+from PyQt5 import QtGui, QtCore, uic
 
 from .errors import CircleCraterError
 

--- a/circle_craters.py
+++ b/circle_craters.py
@@ -371,7 +371,7 @@ class CircleCraters(object):
             '#',
             'Area <km^2> = {}'.format(total_area),
             '#',
-            '#vertex_id, area_number, ext, lon, lat',
+            # '#vertex_id, area_number, ext, lon, lat',
             '',
         ]
         return '\n'.join(header)
@@ -458,10 +458,12 @@ class CircleCraters(object):
         # refer to an attribute by its index
         field_list = [
             str(self.convert_meters_to_km(attributes[diameter])),
+            #str(1),
             # fraction was in old craterstats
             # str(fraction),
             str(attributes[lon]),
-            str(attributes[lat]),
+            str(attributes[lat])
+            #str(1)
         ]
         return field_list
 
@@ -525,6 +527,9 @@ class CircleCraters(object):
         # WARNING INTERSECTS 
         craters = [c for c in craters if self.intersects(c, new_geometries, lat, lon)]
         print("CRATERS: ",craters)
+        # Craterstats 2.0 line is:
+        # crater = {diam, fraction, lon, lat, topo_scale_factor
+        # 12.0185588932   1       159.43028979    16.9521753319   1
         return [self.get_fields(c, diameter, lon, lat) for c in craters]
 
     def get_transformed_polygon(self, feature, distance_area, xform):

--- a/export_dialog.py
+++ b/export_dialog.py
@@ -23,7 +23,7 @@
 
 import os
 
-from PyQt4 import QtGui, QtCore, uic
+from PyQt5 import QtGui, QtCore, uic
 
 from .errors import CircleCraterError
 

--- a/metadata.txt
+++ b/metadata.txt
@@ -19,10 +19,12 @@ email=braden.sarah@gmail.com
 # Optional items:
 
 # Uncomment the following line and add your changelog:
-changelog=CHANGELOG.md
+changelog=Changelog of CircleCraters:
+    0.1 - First release for QGIS 2.6 and CraterStats (1.0)
+    0.2 - Ported to python3/QGIS 3.x  
 
 # Tags are comma separated with spaces allowed
-tags=
+tags=planetary geology, mapping
 
 homepage=https://github.com/sbraden/circle-craters
 tracker=

--- a/metadata.txt
+++ b/metadata.txt
@@ -8,9 +8,9 @@
 
 [general]
 name=Circle Craters
-qgisMinimumVersion=2.0
+qgisMinimumVersion=3.0
 description=A crater counting tool for planetary science
-version=0.1
+version=0.2
 author=Sarah E Braden
 email=braden.sarah@gmail.com
 
@@ -19,7 +19,7 @@ email=braden.sarah@gmail.com
 # Optional items:
 
 # Uncomment the following line and add your changelog:
-# changelog=
+changelog=CHANGELOG.md
 
 # Tags are comma separated with spaces allowed
 tags=

--- a/metadata.txt
+++ b/metadata.txt
@@ -36,3 +36,5 @@ experimental=True
 # deprecated flag (applies to the whole plugin, not just a single version)
 deprecated=False
 
+; if empty, it will be automatically set to major version + .99
+qgisMaximumVersion=3.99

--- a/shapes.py
+++ b/shapes.py
@@ -157,7 +157,7 @@ class Circle(object):
         )
 
     def to_polygon(self, segments=64):
-        thetas = [(2 * math.pi) / segments * i for i in xrange(segments)]
+        thetas = [(2 * math.pi) / segments * i for i in range(segments)]
         return [self.point_at(theta) for theta in thetas]
 
     def __repr__(self):

--- a/test/qgis_interface.py
+++ b/test/qgis_interface.py
@@ -24,7 +24,7 @@ __copyright__ = (
 )
 
 import logging
-from PyQt4.QtCore import QObject, pyqtSlot, pyqtSignal
+from PyQt5.QtCore import QObject, pyqtSlot, pyqtSignal
 from qgis.core import QgsMapLayerRegistry
 from qgis.gui import QgsMapCanvasLayer
 LOGGER = logging.getLogger('QGIS')

--- a/test/test_circle_craters_dialog.py
+++ b/test/test_circle_craters_dialog.py
@@ -14,7 +14,7 @@ __copyright__ = 'Copyright 2014, Sarah E Braden'
 
 import unittest
 
-from PyQt4.QtGui import QDialogButtonBox, QDialog
+from PyQt5.QtGui import QDialogButtonBox, QDialog
 
 from circle_craters_dialog import CircleCratersDialog
 

--- a/test/test_resources.py
+++ b/test/test_resources.py
@@ -14,7 +14,7 @@ __copyright__ = 'Copyright 2014, Sarah E Braden'
 
 import unittest
 
-from PyQt4.QtGui import QIcon
+from PyQt5.QtGui import QIcon
 
 
 

--- a/test/test_translations.py
+++ b/test/test_translations.py
@@ -16,7 +16,7 @@ __copyright__ = ('Copyright 2012, Australia Indonesia Facility for '
 import unittest
 import os
 
-from PyQt4.QtCore import QCoreApplication, QTranslator
+from PyQt5.QtCore import QCoreApplication, QTranslator
 
 QGIS_APP = get_qgis_app()
 

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -23,7 +23,7 @@ def get_qgis_app():
     """
 
     try:
-        from PyQt4 import QtGui, QtCore
+        from PyQt5 import QtGui, QtCore
         from qgis.core import QgsApplication
         from qgis.gui import QgsMapCanvas
         from qgis_interface import QgisInterface


### PR DESCRIPTION
code update to get Circle-Craters working on the latest python3/QGIS 3.x series.   Tested on QGIS-3.16 on OSX and GNU/Linux.

 