### PR TITLE
Bug fix AttributeError of QDialog, unique feature id, OSX build instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ help/_build/
 
 # PyBuilder
 target/
+
+# OSX
+.DS_Store

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,3 +12,4 @@ Contributors
 
 * Trevor Olson <trevor@heytrevor.com>
 * Alessandro Frigeri <alessandro.frigeri@inaf.it>
+* Bojun Jia <jbj0901@foxmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [0.2] - 2019-06-14
 ### Changed
 - Ported to QGIS 3.x by [@afrigeri](https://github.com/afrigeri), after adaptations done for a journal paper: https://doi.org/10.1016/j.icarus.2018.08.015 (see supplementary materials)
+
+## [0.2.1] - 2021-1-16
+### Changed
+- Solved QDialog import error
+- Added instruction of make dependencies on OSX
+- Add .gpkg compatibility (feature id is unique)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,3 +7,15 @@ History
 ~~~~~~~~~~~
 
 * First release.
+
+
+0.2.0 
+~~~~~~~~~~~
+
+* Ported to QGIS3.x by Alessandro Frigeri <alessandro.frigeri@inaf.it>
+
+
+0.2.1
+~~~~~~~~~~~
+
+* Bug fix and added gpkg file compatibility

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ deploy: compile doc transcompile
 	@echo "------------------------------------------"
 	# The deploy  target only works on unix like operating system where
 	# the Python plugin directory is located at:
-	# $HOME/$(QGISDIR)/python/plugins
+	# ${HOME}/$(QGISDIR)/python/plugins
 	mkdir -p $(HOME)/$(QGISDIR)/python/plugins/$(PLUGINNAME)
 	cp -vf $(PY_FILES) $(HOME)/$(QGISDIR)/python/plugins/$(PLUGINNAME)
 	cp -vf $(UI_FILES) $(HOME)/$(QGISDIR)/python/plugins/$(PLUGINNAME)

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ test: compile transcompile
 deploy: compile doc transcompile
 	@echo
 	@echo "------------------------------------------"
-	@echo "Deploying plugin to your .qgis2 directory."
+	@echo "Deploying plugin to your .qgis2/ .qgis3 directory."
 	@echo "------------------------------------------"
 	# The deploy  target only works on unix like operating system where
 	# the Python plugin directory is located at:

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ ifeq ($(OS_NAME), linux)
 QGIS_PY_DIR=".local/share/QGIS/QGIS3/profiles/default/"
 endif
 ifeq ($(OS_NAME), darwin)
-QGIS_PY_DIR="Library/Application Support/QGIS/QGIS3/profiles/default/"
+QGIS_PY_DIR=Library/Application\ Support/QGIS/QGIS3/profiles/default
 endif
 
 # QGIS_PY_DIR=$$HOME/pippo

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,13 @@ Installation
 
    If you see this message install the Python Qt4 developer tools by running::
 
-       $ sudo apt-get install pyqt5-dev-tool.
+   On GNU/Linux systems,
+
+       $ sudo apt-get install pyqt5-dev-tool
+
+   On OSX system,
+
+       $ brew install pyqt
 
    Another commmon error::
 
@@ -69,7 +75,15 @@ Installation
 
    If you see this message install the python sphinx library by running::
 
+   On GNU/Linux systems,
+
        $ sudo apt-get install python-sphinx
+
+   On OSX system,
+
+       $ brew install sphinx-doc
+   
+   And make sure that sphinx has been added to system PATH.
 
 6. Enable the plugin from the QGIS plugin manager. Go to Plugins > Manage and
    Install Plugins. This will connect you to the official QGIS plugin

--- a/README.rst
+++ b/README.rst
@@ -61,11 +61,11 @@ Installation
 
    If you see this message install the Python Qt4 developer tools by running::
 
-   On GNU/Linux systems,
+   On GNU/Linux systems::
 
        $ sudo apt-get install pyqt5-dev-tool
 
-   On OSX system,
+   On OSX system::
 
        $ brew install pyqt
 
@@ -75,15 +75,15 @@ Installation
 
    If you see this message install the python sphinx library by running::
 
-   On GNU/Linux systems,
+   On GNU/Linux systems::
 
        $ sudo apt-get install python-sphinx
 
-   On OSX system,
+   On OSX system::
 
        $ brew install sphinx-doc
    
-   And make sure that sphinx has been added to system PATH.
+   Notice that sphinx is keg-only by default. Please make sure that sphinx has been added to system PATH.
 
 6. Enable the plugin from the QGIS plugin manager. Go to Plugins > Manage and
    Install Plugins. This will connect you to the official QGIS plugin

--- a/choose_layers_dialog.py
+++ b/choose_layers_dialog.py
@@ -14,7 +14,7 @@
 
 import os
 
-from PyQt5 import QtGui, QtCore, uic
+from PyQt5 import QtGui, QtCore, uic, QtWidgets
 
 from .errors import CircleCraterError
 
@@ -23,7 +23,7 @@ ChooseLayersDialogBase, _ = uic.loadUiType(os.path.join(
     os.path.dirname(__file__), 'choose_layers_dialog_base.ui'))
 
 
-class ChooseLayersDialog(QtGui.QDialog, ChooseLayersDialogBase):
+class ChooseLayersDialog(QtWidgets.QDialog, ChooseLayersDialogBase):
     selected = QtCore.pyqtSignal(object)
 
     def __init__(self, parent=None):

--- a/circle_craters.py
+++ b/circle_craters.py
@@ -371,7 +371,7 @@ class CircleCraters(object):
             '#',
             'Area <km^2> = {}'.format(total_area),
             '#',
-            # '#vertex_id, area_number, ext, lon, lat',
+            '# diameter, lon, lat',
             '',
         ]
         return '\n'.join(header)
@@ -449,7 +449,7 @@ class CircleCraters(object):
 
     def get_fields(self, feature, diameter, lon, lat):
         """Retrieves fields from the attribute table in the order required
-        for .diam file: diameter, fraction, lon, lat
+        for .diam file: diameter, lon, lat
         And casts as strings"""
         # diameter is in units of km
         attributes = feature.attributes()

--- a/circle_craters.py
+++ b/circle_craters.py
@@ -619,6 +619,7 @@ class CircleCraters(object):
 
         feature = QgsFeature()
         feature.setGeometry(geometry)
+        feature.setFields(self.layer.fields())
 
         destination = self.layer.crs()
         source = self.layer.crs()
@@ -650,12 +651,9 @@ class CircleCraters(object):
 
         # circle_feature.id() is NULL right now
         # order is id, diameter, lon, lat
-        feature.setAttributes([
-            feature.id(),
-            actual_line_distance * 2,
-            center_in_degrees[0],
-            center_in_degrees[1],
-        ])
+        feature.setAttribute('diameter',actual_line_distance * 2)
+        feature.setAttribute('center_lon',center_in_degrees[0])
+        feature.setAttribute('center_lat',center_in_degrees[1])
 
         self.layer.startEditing()
         self.layer.dataProvider().addFeatures([feature])

--- a/circle_craters.py
+++ b/circle_craters.py
@@ -358,7 +358,7 @@ class CircleCraters(object):
         except CircleCraterError as error:
             self.show_error(error.message)
 
-    def create_diam_header(self, total_area):
+    def create_diam_header(self, total_area, crater_layer):
         current_datetime = str(datetime.datetime.now())
         # a,b = self.get_a_and_b(self.layer)
         da = self.get_distance_area(self.layer)
@@ -369,7 +369,7 @@ class CircleCraters(object):
                 '',
                 'Ellipsoid {}'.format(da.ellipsoid()),
                 '',
-                'layer CRS: {}'.format(self.layer.crs().description()),
+                'layer CRS: {}'.format(crater_layer.crs().description()),
                 '',
                 'Total Crater Area <km^2> = {}'.format(total_area),
                 '',
@@ -395,7 +395,7 @@ class CircleCraters(object):
         total_area = self.compute_area(area_layer)
         km_squared = self.convert_square_meters_to_km(total_area)
 
-        header = self.create_diam_header(km_squared)
+        header = self.create_diam_header(km_squared, crater_layer)
         nested_list = self.format_diam_data(crater_layer, area_layer)
 
         # tab delimited datafile

--- a/circle_craters.py
+++ b/circle_craters.py
@@ -649,7 +649,8 @@ class CircleCraters(object):
         # Translate circle center to units of degrees
         center_in_degrees = xform.transform(circle.center.x, circle.center.y)
 
-        # circle_feature.id() is NULL right now
+        # circle_feature.id() is NULL for .shp file
+        # and assigned automaticly for .gpkg
         # order is id, diameter, lon, lat
         feature.setAttribute('diameter',actual_line_distance * 2)
         feature.setAttribute('center_lon',center_in_degrees[0])

--- a/errors.py
+++ b/errors.py
@@ -2,4 +2,5 @@
 
 
 class CircleCraterError(Exception):
-    pass
+    def __init__(self, message_str = ''):
+        message = message_str

--- a/errors.py
+++ b/errors.py
@@ -3,4 +3,4 @@
 
 class CircleCraterError(Exception):
     def __init__(self, message_str = ''):
-        message = message_str
+        self.message = message_str

--- a/export_dialog.py
+++ b/export_dialog.py
@@ -48,7 +48,7 @@ class ExportDialog(QtWidgets.QDialog, ExportDialogBase):
         self.filename_choose_button.clicked.connect(self.choose_file)
 
     def choose_file(self):
-        self.filename_input.setText(QtGui.QFileDialog.getSaveFileName())
+        self.filename_input.setText(QtWidgets.QFileDialog.getSaveFileName()[0])
 
     def show(self, choices):
         if not choices:

--- a/export_dialog.py
+++ b/export_dialog.py
@@ -23,7 +23,7 @@
 
 import os
 
-from PyQt5 import QtGui, QtCore, uic
+from PyQt5 import QtGui, QtCore, uic, QtWidgets
 
 from .errors import CircleCraterError
 
@@ -32,7 +32,7 @@ ExportDialogBase, _ = uic.loadUiType(os.path.join(
     os.path.dirname(__file__), 'export_dialog_base.ui'))
 
 
-class ExportDialog(QtGui.QDialog, ExportDialogBase):
+class ExportDialog(QtWidgets.QDialog, ExportDialogBase):
     selected = QtCore.pyqtSignal(object, object, str)
 
     def __init__(self, parent=None):

--- a/metadata.txt
+++ b/metadata.txt
@@ -22,6 +22,7 @@ email=braden.sarah@gmail.com
 changelog=Changelog of CircleCraters:
     0.1 - First release for QGIS 2.6 and CraterStats (1.0)
     0.2 - Ported to python3/QGIS 3.x  
+    0.2.1 - Bug fix and gpkg compatibility
 
 # Tags are comma separated with spaces allowed
 tags=planetary geology, mapping

--- a/shapes.py
+++ b/shapes.py
@@ -132,7 +132,7 @@ class Circle(object):
         if len(vertices) != 3:
             raise ValueError('a circle must have three vertices')
 
-        if Point.is_collinear(vertices):
+        if Point.is_collinear(vertices, error=1e-2):
             raise ValueError('vertices are collinear')
 
         self.vertices = vertices

--- a/shapes.py
+++ b/shapes.py
@@ -50,8 +50,9 @@ class Point(object):
 
         for point in points:
             delta_b = point - p1
-            determinant = (delta_a.x * delta_b.y) - (delta_a.y * delta_b.x)
-            if abs(determinant) > error:
+            # cosine of delta_a and delta_b
+            determinant = (delta_a.x * delta_b.x + delta_a.y * delta_b.y)/math.sqrt(delta_a.x**2+delta_a.y**2)/math.sqrt(delta_b.x**2+delta_b.y**2)
+            if (1.0 - abs(determinant)) > error:
                 return False
 
         return True

--- a/test/test_circle_craters_dialog.py
+++ b/test/test_circle_craters_dialog.py
@@ -14,7 +14,7 @@ __copyright__ = 'Copyright 2014, Sarah E Braden'
 
 import unittest
 
-from PyQt5.QtGui import QDialogButtonBox, QDialog
+from PyQt5.QtWidgets import QDialogButtonBox, QDialog
 
 from circle_craters_dialog import CircleCratersDialog
 


### PR DESCRIPTION
**Changes**

1. In PyQt4, QDialog and QFileDialog is in QtGui. As for PyQt5, QDialog and QFileDialog had moved form QtGui to QtWidgets. I changed a little bit so that this plugin can be imported correctly.

2. By default, circle-craters can only create features with fid=0. This can cause truble when edit a gpkg file, since fid must be unique in gpkg files. I left feature id without assignment. So for .shp files, fid is NULL, and for .gpkg files, fid is assigned automatically.

3. Updated collinearity condition, so it can avoid precision loss at small scale when using geographic coordinate systems which use degrees as distance unit instead of local projection coordinate systems, though custom projection coordinate system is recommended for better precision.  
By doing so, Circle Craters can be used for small crater or rock counting in high resolution images with a relative high precision in geographic coordinate systems

4. Using project specified ellipsoid when layer specified ellipsoid is not available, and prompt used ellipsoid and crs in export file header.

4. Add build instructions and some other information.

It has been test on both QGIS 3.10 and QGIS 3.16 on MacOS 10.15.7. 

Tested functions: start and stop counting, circling multiple craters and export data.

@sbraden @afrigeri  Thank you for your contribution. I'm not very familiar with PyQGIS and PyQt, please let me know if there is anything wrong.